### PR TITLE
Add manual guidance workflow with admin file management

### DIFF
--- a/handlers/admin/manuals_management.py
+++ b/handlers/admin/manuals_management.py
@@ -1,0 +1,55 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery, Message, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.fsm.state import StatesGroup, State
+from aiogram.fsm.context import FSMContext
+from keyboards.inline import get_manuals_admin_menu
+from database.db import set_manual_file
+import logging
+
+router = Router()
+logger = logging.getLogger(__name__)
+
+class ManualUpload(StatesGroup):
+    waiting_for_file = State()
+
+@router.callback_query(F.data == "manage_manuals")
+async def manage_manuals(callback: CallbackQuery, state: FSMContext):
+    await state.clear()
+    await callback.message.edit_text("Выберите руководство для загрузки:", reply_markup=get_manuals_admin_menu())
+    await callback.answer()
+
+@router.callback_query(F.data.startswith("upload_manual_"))
+async def prompt_manual_upload(callback: CallbackQuery, state: FSMContext):
+    category = callback.data.replace("upload_manual_", "")
+    await state.update_data(category=category)
+    await callback.message.edit_text(
+        "Отправьте файл руководства:",
+        reply_markup=InlineKeyboardMarkup(inline_keyboard=[
+            [InlineKeyboardButton(text="⬅️ Назад", callback_data="manage_manuals")]
+        ])
+    )
+    await state.set_state(ManualUpload.waiting_for_file)
+    await callback.answer()
+
+@router.message(ManualUpload.waiting_for_file, F.document)
+async def receive_manual_file(message: Message, state: FSMContext):
+    data = await state.get_data()
+    category = data.get("category")
+    file_id = message.document.file_id
+    await set_manual_file(category, file_id)
+    await message.answer(
+        "Файл сохранён.",
+        reply_markup=InlineKeyboardMarkup(inline_keyboard=[
+            [InlineKeyboardButton(text="⬅️ Назад", callback_data="manage_manuals")]
+        ])
+    )
+    await state.clear()
+
+@router.message(ManualUpload.waiting_for_file)
+async def invalid_manual_file(message: Message):
+    await message.answer(
+        "Пожалуйста, отправьте файл.",
+        reply_markup=InlineKeyboardMarkup(inline_keyboard=[
+            [InlineKeyboardButton(text="⬅️ Назад", callback_data="manage_manuals")]
+        ])
+    )

--- a/keyboards/inline.py
+++ b/keyboards/inline.py
@@ -16,6 +16,17 @@ def get_user_menu():
     logger.debug("Создана клавиатура для пользовательского меню")
     return keyboard
 
+def get_manuals_menu():
+    keyboard = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="Настройка пульта", callback_data="manual_remote")],
+        [InlineKeyboardButton(text="Прошивка ЕРЛС", callback_data="manual_erlc")],
+        [InlineKeyboardButton(text="Настройка НСУ", callback_data="manual_nsu")],
+        [InlineKeyboardButton(text="Руководство по дрону", callback_data="manual_drone")],
+        [InlineKeyboardButton(text="⬅️ Назад", callback_data="main_menu")]
+    ])
+    logger.debug("Создана клавиатура меню руководств")
+    return keyboard
+
 def get_exam_menu():
     keyboard = InlineKeyboardMarkup(inline_keyboard=[
         [InlineKeyboardButton(text="Принять экзамен", callback_data="take_exam")],
@@ -137,6 +148,7 @@ def get_admin_panel_menu():
         [InlineKeyboardButton(text="👥 Проверить заявки сотрудников", callback_data="check_employee_appeals")],
         [InlineKeyboardButton(text="📊 Статистика сотрудников", callback_data="stats")],
         [InlineKeyboardButton(text="⚙️ Управление базой", callback_data="manage_base")],
+        [InlineKeyboardButton(text="📚 Руководства", callback_data="manage_manuals")],
         [InlineKeyboardButton(text="👤 Добавить сотрудника", callback_data="add_employee")],
         [InlineKeyboardButton(text="📢 Добавить канал/группу", callback_data="add_channel")],
         [InlineKeyboardButton(text="🗑 Удалить канал/группу", callback_data="remove_channel")],
@@ -196,6 +208,15 @@ def get_defect_status_menu(serial):
         [InlineKeyboardButton(text="Возврат", callback_data=f"defect_status_vozvrat_{serial}")],
         [InlineKeyboardButton(text="Замена", callback_data=f"defect_status_zamena_{serial}")],
         [InlineKeyboardButton(text="⬅️ Назад", callback_data="main_menu")]
+    ])
+
+def get_manuals_admin_menu():
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="Настройка пульта", callback_data="upload_manual_remote")],
+        [InlineKeyboardButton(text="Прошивка ЕРЛС", callback_data="upload_manual_erlc")],
+        [InlineKeyboardButton(text="Настройка НСУ", callback_data="upload_manual_nsu")],
+        [InlineKeyboardButton(text="Руководство по дрону", callback_data="upload_manual_drone")],
+        [InlineKeyboardButton(text="⬅️ Назад", callback_data="admin_panel")]
     ])
 
 def get_employee_list_menu(admins):

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from aiogram.webhook.aiohttp_server import SimpleRequestHandler, setup_applicati
 from aiohttp import web
 from config import TOKEN, API_BASE_URL, WEBHOOK_URL, MAIN_ADMIN_IDS
 from handlers import user_handlers, common_handlers, user_exam
-from handlers.admin import serial_history, appeal_actions, admin_panel, defect_management, base_management, overdue_checks, closed_appeals
+from handlers.admin import serial_history, appeal_actions, admin_panel, defect_management, base_management, overdue_checks, closed_appeals, manuals_management
 from database.db import initialize_db, close_db, get_open_appeals, close_appeal
 from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
 from aiogram.client.session.aiohttp import AiohttpSession
@@ -178,6 +178,7 @@ def main():
     dp.include_router(base_management.router)
     dp.include_router(overdue_checks.router)
     dp.include_router(closed_appeals.router)
+    dp.include_router(manuals_management.router)
 
     dp.startup.register(on_startup)
     dp.shutdown.register(on_shutdown)


### PR DESCRIPTION
## Summary
- Add `manuals` table and utilities to store manual file IDs
- Introduce new `/start` scenario with serial validation and manual menu
- Allow admins to upload or replace manual files via admin panel

## Testing
- `python -m py_compile database/db.py keyboards/inline.py handlers/common_handlers.py handlers/admin/manuals_management.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcd0ed52c08332b93dd642d8b61952